### PR TITLE
Ajoute un compteur de croissance pour le serpent

### DIFF
--- a/backend/snake.py
+++ b/backend/snake.py
@@ -111,7 +111,7 @@ class Snake:
     def __init__(self):
         self.positions = [(COLONNES // 2, LIGNES // 2)]
         self.direction = DROITE
-        self.grandir = False
+        self.grandir_restants = 0
         
     def _couleur_arc_en_ciel(self, index_segment: int, current_time: float | None = None) -> tuple:
         """Retourne une couleur arc‑en‑ciel (RGB) pour un segment.
@@ -149,11 +149,11 @@ class Snake:
             return False
             
         self.positions.insert(0, nouvelle_tete)
-        
-        if not self.grandir:
-            self.positions.pop()
+
+        if self.grandir_restants > 0:
+            self.grandir_restants -= 1
         else:
-            self.grandir = False
+            self.positions.pop()
             
         return True
     
@@ -163,7 +163,7 @@ class Snake:
             self.direction = nouvelle_direction
     
     def manger(self):
-        self.grandir = True
+        self.grandir_restants += 3
         
     def dessiner(self, ecran):
         # Cache la valeur temporelle pour cette frame

--- a/tests/test_snake.py
+++ b/tests/test_snake.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+PROJET_RACINE = Path(__file__).resolve().parents[1]
+if str(PROJET_RACINE) not in sys.path:
+    sys.path.insert(0, str(PROJET_RACINE))
+
+from backend.snake import Snake
+
+
+def test_snake_grows_three_segments_per_fruit():
+    snake = Snake()
+    initial_length = len(snake.positions)
+
+    snake.manger()
+    assert snake.grandir_restants == 3
+
+    lengths = []
+    for _ in range(3):
+        assert snake.bouger() is True
+        lengths.append(len(snake.positions))
+
+    assert lengths == [initial_length + 1, initial_length + 2, initial_length + 3]
+    assert snake.grandir_restants == 0
+
+    assert snake.bouger() is True
+    assert len(snake.positions) == initial_length + 3
+
+
+def test_snake_growth_counter_accumulates():
+    snake = Snake()
+    initial_length = len(snake.positions)
+
+    snake.manger()
+    snake.manger()
+
+    assert snake.grandir_restants == 6
+
+    for step in range(6):
+        assert snake.bouger() is True
+        assert len(snake.positions) == initial_length + 1 + step
+
+    assert snake.grandir_restants == 0
+
+    assert snake.bouger() is True
+    assert len(snake.positions) == initial_length + 6


### PR DESCRIPTION
## Summary
- remplacer le booléen de croissance par un compteur exploité lors des déplacements
- augmenter ce compteur de trois unités à chaque fruit mangé
- ajouter des tests garantissant l'allongement de trois segments par fruit

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f94d6b2d0483238b24b4daf521eb40