### PR TITLE
Add React frontend dashboard for ABC KPI platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+node_modules/
+frontend/node_modules/
+frontend/dist/
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,83 @@
-# test
-# teste
-# teste
-# test
-# test
+# ABC KPI Platform (Sample Implementation)
+
+Cette implémentation fournit une version simplifiée de la plateforme d'analytics
+présentée sur le site ABC KPI. Elle permet de charger des transactions marketing,
+de calculer un ensemble d'indicateurs clés de performance (KPI) et de générer un
+rapport texte.
+
+## Fonctionnalités
+
+- Chargement de données CSV avec validation du schéma.
+- Calcul automatisé de KPI standards (revenu total, nombre de commandes,
+taux de conversion, panier moyen...).
+- Segmentation des KPI par dimension (canal, campagne, produit, etc.).
+- Interface en ligne de commande pour produire un rapport instantané.
+- Tableau de bord React moderne pour explorer les KPI en quelques clics.
+
+## Prise en main rapide
+
+1. Créez (ou utilisez) un fichier CSV conforme au schéma suivant :
+
+   ```csv
+   date,revenue,leads,orders,channel,campaign,product
+   2024-01-01,1250.50,120,24,Email,Winter Blast,Analytics Suite
+   ```
+
+   Un fichier d'exemple est disponible dans `data/sample_transactions.csv`.
+
+2. Exécutez la CLI :
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .
+   python main.py data/sample_transactions.csv --dimension channel
+   ```
+
+3. Résultat attendu :
+
+   ```
+   === KPI SUMMARY ===
+   - Total Revenue: 13 358.55 € — Sum of revenue across all transactions.
+   - Orders: 266.00 orders — Total number of orders.
+   - Leads: 1 330.00 leads — Total marketing leads captured.
+   - Conversion Rate: 20.00 % — Orders divided by leads.
+   - Average Order Value: 50.22 € — Revenue divided by number of orders.
+   - Revenue per Lead: 10.04 € — Revenue divided by number of leads.
+
+   ## Ads
+   === KPI SUMMARY ===
+   ...
+   ```
+
+## Interface web (React)
+
+Une application React est fournie dans le dossier `frontend/`. Elle propose :
+
+- un sélecteur de dimension (canal, campagne, produit) pour segmenter les KPI ;
+- des filtres multi-sélection par canal, campagne et produit ;
+- une visualisation sous forme de cartes KPI et de tableau comparatif par segment ;
+- l'accès aux données brutes pour export rapide.
+
+### Lancer le tableau de bord
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+L'application est servie par Vite sur [http://localhost:5173](http://localhost:5173).
+
+## Structure du projet
+
+- `abckpi_platform/` : cœurs de modules (chargement, calcul, reporting).
+- `frontend/` : application React (Vite) pour l'interface web.
+- `main.py` : interface CLI.
+- `data/` : exemples de données.
+- `snake.py` : mini-jeu conservé comme exemple historique.
+
+## Tests
+
+Aucun test automatisé n'est fourni, mais la CLI peut être exécutée avec votre
+propre fichier CSV pour valider les calculs.

--- a/abckpi_platform/__init__.py
+++ b/abckpi_platform/__init__.py
@@ -1,0 +1,10 @@
+"""AbcKPI Platform package."""
+from .data_loader import load_transactions
+from .kpi_engine import KPIEngine
+from .reporting import format_report
+
+__all__ = [
+    "load_transactions",
+    "KPIEngine",
+    "format_report",
+]

--- a/abckpi_platform/data_loader.py
+++ b/abckpi_platform/data_loader.py
@@ -1,0 +1,80 @@
+"""Utilities to load transactional data for the ABC KPI platform."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class DataSchema:
+    """Describe the mandatory columns required by the platform."""
+
+    date_column: str = "date"
+    revenue_column: str = "revenue"
+    lead_column: str = "leads"
+    order_column: str = "orders"
+
+    optional_columns: tuple[str, ...] = ("channel", "campaign", "product")
+
+    def validate(self, frame: pd.DataFrame) -> None:
+        """Validate that the dataframe contains at least the required columns."""
+        missing = [col for col in self.required_columns if col not in frame.columns]
+        if missing:
+            raise ValueError(
+                "Missing required columns: " + ", ".join(sorted(missing))
+            )
+
+    @property
+    def required_columns(self) -> tuple[str, str, str, str]:
+        return (self.date_column, self.revenue_column, self.lead_column, self.order_column)
+
+
+def load_transactions(
+    path: str | Path,
+    *,
+    schema: Optional[DataSchema] = None,
+    date_format: Optional[str] = None,
+    filters: Optional[Iterable[tuple[str, str | float | int]]] = None,
+) -> pd.DataFrame:
+    """Load a CSV file containing transactional information.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    schema:
+        Optional schema definition. By default, :class:`DataSchema` is used.
+    date_format:
+        Optional strptime format. If provided, the date column will be parsed using
+        the format; otherwise pandas will infer the format.
+    filters:
+        Optional iterable of (column, value) pairs used to filter the resulting
+        dataframe.
+    """
+
+    csv_path = Path(path)
+    if not csv_path.exists():
+        raise FileNotFoundError(csv_path)
+
+    schema = schema or DataSchema()
+
+    frame = pd.read_csv(csv_path)
+
+    # Parse the date column using pandas for robust handling of multiple formats.
+    frame[schema.date_column] = pd.to_datetime(frame[schema.date_column], format=date_format)
+
+    schema.validate(frame)
+
+    if filters:
+        for column, value in filters:
+            if column not in frame.columns:
+                raise KeyError(f"Unknown filter column: {column}")
+            frame = frame.loc[frame[column] == value]
+
+    return frame.reset_index(drop=True)
+
+
+__all__ = ["DataSchema", "load_transactions"]

--- a/abckpi_platform/kpi_engine.py
+++ b/abckpi_platform/kpi_engine.py
@@ -1,0 +1,106 @@
+"""Core KPI engine for the ABC KPI platform."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class KPIResult:
+    """Represents a computed KPI."""
+
+    name: str
+    value: float
+    unit: str
+    description: str
+
+
+class KPIEngine:
+    """Compute business KPIs from transactional data."""
+
+    def __init__(self, frame: pd.DataFrame, *, currency: str = "€") -> None:
+        self._frame = frame
+        self.currency = currency
+
+        # Pre-computed aggregates for efficiency.
+        self._revenue_total = float(frame["revenue"].sum())
+        self._order_total = int(frame["orders"].sum())
+        self._lead_total = int(frame["leads"].sum())
+
+    def compute(self) -> list[KPIResult]:
+        """Compute the default KPI set."""
+
+        results = [
+            KPIResult(
+                name="Total Revenue",
+                value=self._revenue_total,
+                unit=self.currency,
+                description="Sum of revenue across all transactions.",
+            ),
+            KPIResult(
+                name="Orders",
+                value=float(self._order_total),
+                unit="orders",
+                description="Total number of orders.",
+            ),
+            KPIResult(
+                name="Leads",
+                value=float(self._lead_total),
+                unit="leads",
+                description="Total marketing leads captured.",
+            ),
+            KPIResult(
+                name="Conversion Rate",
+                value=self._compute_conversion_rate(),
+                unit="%",
+                description="Orders divided by leads.",
+            ),
+            KPIResult(
+                name="Average Order Value",
+                value=self._compute_average_order_value(),
+                unit=self.currency,
+                description="Revenue divided by number of orders.",
+            ),
+            KPIResult(
+                name="Revenue per Lead",
+                value=self._compute_revenue_per_lead(),
+                unit=self.currency,
+                description="Revenue divided by number of leads.",
+            ),
+        ]
+
+        return results
+
+    def by_dimension(self, column: str) -> Mapping[str, list[KPIResult]]:
+        """Compute KPIs grouped by the provided column."""
+        if column not in self._frame.columns:
+            raise KeyError(f"Unknown dimension: {column}")
+
+        grouped = self._frame.groupby(column)
+        report: dict[str, list[KPIResult]] = {}
+
+        for dimension_value, frame in grouped:
+            engine = KPIEngine(frame, currency=self.currency)
+            report[str(dimension_value)] = engine.compute()
+
+        return report
+
+    def _compute_conversion_rate(self) -> float:
+        if self._lead_total == 0:
+            return 0.0
+        return round((self._order_total / self._lead_total) * 100, 2)
+
+    def _compute_average_order_value(self) -> float:
+        if self._order_total == 0:
+            return 0.0
+        return round(self._revenue_total / self._order_total, 2)
+
+    def _compute_revenue_per_lead(self) -> float:
+        if self._lead_total == 0:
+            return 0.0
+        return round(self._revenue_total / self._lead_total, 2)
+
+
+__all__ = ["KPIEngine", "KPIResult"]

--- a/abckpi_platform/reporting.py
+++ b/abckpi_platform/reporting.py
@@ -1,0 +1,28 @@
+"""Reporting utilities for the ABC KPI platform."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from .kpi_engine import KPIResult
+
+
+def format_report(results: Iterable[KPIResult]) -> str:
+    """Return a human friendly textual representation of KPI results."""
+    lines = ["=== KPI SUMMARY ==="]
+    for result in results:
+        lines.append(
+            f"- {result.name}: {result.value:,.2f} {result.unit} — {result.description}"
+        )
+    return "\n".join(lines)
+
+
+def format_grouped_report(grouped: Mapping[str, Iterable[KPIResult]]) -> str:
+    """Return a multi-section string summarising KPIs for each group."""
+    sections: list[str] = []
+    for group, results in grouped.items():
+        sections.append(f"\n## {group}")
+        sections.append(format_report(results))
+    return "\n".join(sections)
+
+
+__all__ = ["format_report", "format_grouped_report"]

--- a/data/sample_transactions.csv
+++ b/data/sample_transactions.csv
@@ -1,0 +1,11 @@
+date,revenue,leads,orders,channel,campaign,product
+2024-01-01,1250.50,120,24,Email,Winter Blast,Analytics Suite
+2024-01-02,980.00,90,18,Email,Winter Blast,Analytics Suite
+2024-01-03,1420.75,150,30,Ads,Search 2024,Marketing Hub
+2024-01-04,1110.25,80,16,Ads,Retargeting,Analytics Suite
+2024-01-05,1675.00,200,40,Direct,Website,Marketing Hub
+2024-01-06,890.30,75,15,Partners,Agency,Analytics Suite
+2024-01-07,2100.90,220,44,Ads,Search 2024,Analytics Suite
+2024-01-08,1345.10,140,28,Email,New Leads,Marketing Hub
+2024-01-09,1560.00,160,32,Direct,Website,Analytics Suite
+2024-01-10,1025.75,95,19,Partners,Agency,Marketing Hub

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ABC KPI Platform</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "abckpi-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.33.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,105 @@
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+  display: grid;
+  gap: 40px;
+}
+
+.app__hero {
+  text-align: center;
+  display: grid;
+  gap: 16px;
+}
+
+.app__badge {
+  margin: 0 auto;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.app__hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 3rem);
+  color: #0f172a;
+}
+
+.app__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #475569;
+}
+
+.app__content {
+  display: grid;
+  gap: 32px;
+}
+
+.app__filters {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.app__kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.app__raw-data {
+  background: white;
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.app__raw-data header h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.app__raw-data header p {
+  margin: 4px 0 0;
+  color: #64748b;
+}
+
+.app__table-wrapper {
+  overflow-x: auto;
+}
+
+.app__raw-data table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+}
+
+.app__raw-data th,
+.app__raw-data td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.app__raw-data tbody tr:nth-child(odd) {
+  background: rgba(241, 245, 249, 0.5);
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding: 32px 16px 48px;
+  }
+
+  .app__filters {
+    position: static;
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -42,6 +42,43 @@
   gap: 32px;
 }
 
+.app__tabs {
+  display: inline-flex;
+  justify-content: center;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  align-self: center;
+  margin: 0 auto;
+}
+
+.app__tab {
+  border: none;
+  background: transparent;
+  color: #475569;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.app__tab:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+.app__tab:hover {
+  color: #0f172a;
+}
+
+.app__tab--active {
+  background: white;
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+}
+
 .app__filters {
   position: sticky;
   top: 0;
@@ -97,6 +134,11 @@
 @media (max-width: 768px) {
   .app {
     padding: 32px 16px 48px;
+  }
+
+  .app__tabs {
+    flex-wrap: wrap;
+    row-gap: 8px;
   }
 
   .app__filters {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,11 @@ const DIMENSIONS = [
 
 const FILTER_FIELDS = DIMENSIONS;
 
+const TABS = [
+  { id: 'dashboard', label: 'Tableau de bord' },
+  { id: 'indicators', label: 'Indicateurs clés' }
+];
+
 const CURRENCY_FORMATTER = new Intl.NumberFormat('fr-FR', {
   style: 'currency',
   currency: 'EUR'
@@ -67,6 +72,7 @@ function buildFilterState() {
 function App() {
   const [selectedDimension, setSelectedDimension] = useState(DIMENSIONS[0].value);
   const [filters, setFilters] = useState(buildFilterState);
+  const [activeTab, setActiveTab] = useState(TABS[0].id);
 
   const filterOptions = useMemo(
     () =>
@@ -188,67 +194,85 @@ function App() {
         </p>
       </header>
 
+      <nav className="app__tabs" aria-label="Sections du tableau de bord">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`app__tab ${tab.id === activeTab ? 'app__tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+            aria-current={tab.id === activeTab ? 'page' : undefined}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
       <main className="app__content">
-        <IndicatorBuilder />
+        {activeTab === 'indicators' ? (
+          <IndicatorBuilder />
+        ) : (
+          <>
+            <section className="app__filters">
+              <FilterPanel
+                dimensions={DIMENSIONS}
+                selectedDimension={selectedDimension}
+                onDimensionChange={setSelectedDimension}
+                filters={filterOptions}
+                onFilterToggle={handleFilterToggle}
+              />
+            </section>
 
-        <section className="app__filters">
-          <FilterPanel
-            dimensions={DIMENSIONS}
-            selectedDimension={selectedDimension}
-            onDimensionChange={setSelectedDimension}
-            filters={filterOptions}
-            onFilterToggle={handleFilterToggle}
-          />
-        </section>
+            <section className="app__kpis">
+              {summaryCards.map((card) => (
+                <KpiCard
+                  key={card.key}
+                  title={card.title}
+                  value={card.value}
+                  description={card.description}
+                  tone={card.tone}
+                />
+              ))}
+            </section>
 
-        <section className="app__kpis">
-          {summaryCards.map((card) => (
-            <KpiCard
-              key={card.key}
-              title={card.title}
-              value={card.value}
-              description={card.description}
-              tone={card.tone}
-            />
-          ))}
-        </section>
+            <SegmentTable dimensionLabel={dimensionLabel} rows={segments} />
 
-        <SegmentTable dimensionLabel={dimensionLabel} rows={segments} />
-
-        <section className="app__raw-data">
-          <header>
-            <h2>Données transactionnelles brutes</h2>
-            <p>Exportez ces données pour une analyse approfondie ou un partage dans vos outils internes.</p>
-          </header>
-          <div className="app__table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Canal</th>
-                  <th>Campagne</th>
-                  <th>Produit</th>
-                  <th>Revenu</th>
-                  <th>Leads</th>
-                  <th>Commandes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredTransactions.map((transaction) => (
-                  <tr key={`${transaction.date}-${transaction.campaign}-${transaction.channel}`}>
-                    <td>{transaction.date}</td>
-                    <td>{transaction.channel}</td>
-                    <td>{transaction.campaign}</td>
-                    <td>{transaction.product}</td>
-                    <td>{CURRENCY_FORMATTER.format(transaction.revenue)}</td>
-                    <td>{INTEGER_FORMATTER.format(transaction.leads)}</td>
-                    <td>{INTEGER_FORMATTER.format(transaction.orders)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
+            <section className="app__raw-data">
+              <header>
+                <h2>Données transactionnelles brutes</h2>
+                <p>Exportez ces données pour une analyse approfondie ou un partage dans vos outils internes.</p>
+              </header>
+              <div className="app__table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Canal</th>
+                      <th>Campagne</th>
+                      <th>Produit</th>
+                      <th>Revenu</th>
+                      <th>Leads</th>
+                      <th>Commandes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredTransactions.map((transaction) => (
+                      <tr key={`${transaction.date}-${transaction.campaign}-${transaction.channel}`}>
+                        <td>{transaction.date}</td>
+                        <td>{transaction.channel}</td>
+                        <td>{transaction.campaign}</td>
+                        <td>{transaction.product}</td>
+                        <td>{CURRENCY_FORMATTER.format(transaction.revenue)}</td>
+                        <td>{INTEGER_FORMATTER.format(transaction.leads)}</td>
+                        <td>{INTEGER_FORMATTER.format(transaction.orders)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        )}
       </main>
     </div>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import FilterPanel from './components/FilterPanel.jsx';
+import IndicatorBuilder from './components/IndicatorBuilder.jsx';
 import KpiCard from './components/KpiCard.jsx';
 import SegmentTable from './components/SegmentTable.jsx';
 import transactions from './data/sampleTransactions.json';
@@ -188,6 +189,8 @@ function App() {
       </header>
 
       <main className="app__content">
+        <IndicatorBuilder />
+
         <section className="app__filters">
           <FilterPanel
             dimensions={DIMENSIONS}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from 'react';
+import FilterPanel from './components/FilterPanel.jsx';
+import KpiCard from './components/KpiCard.jsx';
+import SegmentTable from './components/SegmentTable.jsx';
+import transactions from './data/sampleTransactions.json';
+import './App.css';
+
+const DIMENSIONS = [
+  { value: 'channel', label: 'Canal' },
+  { value: 'campaign', label: 'Campagne' },
+  { value: 'product', label: 'Produit' }
+];
+
+const FILTER_FIELDS = DIMENSIONS;
+
+const CURRENCY_FORMATTER = new Intl.NumberFormat('fr-FR', {
+  style: 'currency',
+  currency: 'EUR'
+});
+
+const INTEGER_FORMATTER = new Intl.NumberFormat('fr-FR');
+
+function computeAggregates(rows) {
+  const totals = rows.reduce(
+    (acc, row) => {
+      acc.revenue += row.revenue;
+      acc.orders += row.orders;
+      acc.leads += row.leads;
+      return acc;
+    },
+    { revenue: 0, orders: 0, leads: 0 }
+  );
+
+  const conversionRate = totals.leads === 0 ? 0 : (totals.orders / totals.leads) * 100;
+  const averageOrderValue = totals.orders === 0 ? 0 : totals.revenue / totals.orders;
+  const revenuePerLead = totals.leads === 0 ? 0 : totals.revenue / totals.leads;
+
+  return {
+    revenue: totals.revenue,
+    orders: totals.orders,
+    leads: totals.leads,
+    conversionRate: Number(conversionRate.toFixed(2)),
+    averageOrderValue: Number(averageOrderValue.toFixed(2)),
+    revenuePerLead: Number(revenuePerLead.toFixed(2))
+  };
+}
+
+function formatAggregates(aggregates) {
+  return {
+    revenue: CURRENCY_FORMATTER.format(aggregates.revenue),
+    orders: INTEGER_FORMATTER.format(aggregates.orders),
+    leads: INTEGER_FORMATTER.format(aggregates.leads),
+    conversionRate: `${aggregates.conversionRate.toFixed(2)} %`,
+    averageOrderValue: CURRENCY_FORMATTER.format(aggregates.averageOrderValue),
+    revenuePerLead: CURRENCY_FORMATTER.format(aggregates.revenuePerLead)
+  };
+}
+
+function buildFilterState() {
+  return FILTER_FIELDS.reduce((state, field) => ({
+    ...state,
+    [field.value]: []
+  }), {});
+}
+
+function App() {
+  const [selectedDimension, setSelectedDimension] = useState(DIMENSIONS[0].value);
+  const [filters, setFilters] = useState(buildFilterState);
+
+  const filterOptions = useMemo(
+    () =>
+      FILTER_FIELDS.map((field) => ({
+        field: field.value,
+        label: field.label,
+        values: Array.from(new Set(transactions.map((transaction) => transaction[field.value]))).sort(),
+        selected: filters[field.value]
+      })),
+    [filters]
+  );
+
+  const filteredTransactions = useMemo(
+    () =>
+      transactions.filter((transaction) =>
+        FILTER_FIELDS.every((field) => {
+          const selectedValues = filters[field.value];
+          return selectedValues.length === 0 || selectedValues.includes(transaction[field.value]);
+        })
+      ),
+    [filters]
+  );
+
+  const aggregated = useMemo(() => computeAggregates(filteredTransactions), [filteredTransactions]);
+  const formattedAggregates = useMemo(() => formatAggregates(aggregated), [aggregated]);
+
+  const segments = useMemo(() => {
+    if (!selectedDimension) {
+      return [];
+    }
+
+    const groups = new Map();
+
+    filteredTransactions.forEach((transaction) => {
+      const dimensionValue = transaction[selectedDimension] ?? 'Non renseigné';
+      const current = groups.get(dimensionValue) ?? [];
+      current.push(transaction);
+      groups.set(dimensionValue, current);
+    });
+
+    return Array.from(groups.entries())
+      .map(([dimensionValue, rows]) => {
+        const aggregates = computeAggregates(rows);
+        return {
+          dimension: dimensionValue,
+          kpis: formatAggregates(aggregates),
+          rawRevenue: aggregates.revenue
+        };
+      })
+      .sort((a, b) => b.rawRevenue - a.rawRevenue)
+      .map(({ rawRevenue, ...rest }) => rest);
+  }, [filteredTransactions, selectedDimension]);
+
+  const dimensionLabel = DIMENSIONS.find((dimension) => dimension.value === selectedDimension)?.label ?? 'Segment';
+
+  const summaryCards = [
+    {
+      key: 'revenue',
+      title: 'Revenu total',
+      value: formattedAggregates.revenue,
+      description: 'Somme des ventes réalisées sur la période.',
+      tone: 'success'
+    },
+    {
+      key: 'orders',
+      title: 'Commandes',
+      value: formattedAggregates.orders,
+      description: 'Volume de commandes générées.'
+    },
+    {
+      key: 'leads',
+      title: 'Leads marketing',
+      value: formattedAggregates.leads,
+      description: 'Nombre de prospects capturés via vos campagnes.'
+    },
+    {
+      key: 'conversionRate',
+      title: 'Taux de conversion',
+      value: formattedAggregates.conversionRate,
+      description: 'Commandes / Leads.',
+      tone: 'success'
+    },
+    {
+      key: 'averageOrderValue',
+      title: 'Panier moyen',
+      value: formattedAggregates.averageOrderValue,
+      description: 'Revenu moyen par commande.'
+    },
+    {
+      key: 'revenuePerLead',
+      title: 'Revenu par lead',
+      value: formattedAggregates.revenuePerLead,
+      description: 'Montant moyen généré par prospect.',
+      tone: 'warning'
+    }
+  ];
+
+  const handleFilterToggle = (field, value) => {
+    setFilters((previous) => {
+      const selection = previous[field];
+      const exists = selection.includes(value);
+      const updated = exists ? selection.filter((item) => item !== value) : [...selection, value];
+
+      return {
+        ...previous,
+        [field]: updated
+      };
+    });
+  };
+
+  return (
+    <div className="app">
+      <header className="app__hero">
+        <p className="app__badge">Plateforme ABC KPI</p>
+        <h1>Visualisez vos performances marketing en temps réel</h1>
+        <p className="app__subtitle">
+          Analysez vos canaux d&apos;acquisition, identifiez les campagnes les plus rentables et pilotez vos revenus
+          depuis un tableau de bord moderne.
+        </p>
+      </header>
+
+      <main className="app__content">
+        <section className="app__filters">
+          <FilterPanel
+            dimensions={DIMENSIONS}
+            selectedDimension={selectedDimension}
+            onDimensionChange={setSelectedDimension}
+            filters={filterOptions}
+            onFilterToggle={handleFilterToggle}
+          />
+        </section>
+
+        <section className="app__kpis">
+          {summaryCards.map((card) => (
+            <KpiCard
+              key={card.key}
+              title={card.title}
+              value={card.value}
+              description={card.description}
+              tone={card.tone}
+            />
+          ))}
+        </section>
+
+        <SegmentTable dimensionLabel={dimensionLabel} rows={segments} />
+
+        <section className="app__raw-data">
+          <header>
+            <h2>Données transactionnelles brutes</h2>
+            <p>Exportez ces données pour une analyse approfondie ou un partage dans vos outils internes.</p>
+          </header>
+          <div className="app__table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Canal</th>
+                  <th>Campagne</th>
+                  <th>Produit</th>
+                  <th>Revenu</th>
+                  <th>Leads</th>
+                  <th>Commandes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredTransactions.map((transaction) => (
+                  <tr key={`${transaction.date}-${transaction.campaign}-${transaction.channel}`}>
+                    <td>{transaction.date}</td>
+                    <td>{transaction.channel}</td>
+                    <td>{transaction.campaign}</td>
+                    <td>{transaction.product}</td>
+                    <td>{CURRENCY_FORMATTER.format(transaction.revenue)}</td>
+                    <td>{INTEGER_FORMATTER.format(transaction.leads)}</td>
+                    <td>{INTEGER_FORMATTER.format(transaction.orders)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/FilterPanel.css
+++ b/frontend/src/components/FilterPanel.css
@@ -1,0 +1,73 @@
+.filter-panel {
+  background: white;
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 24px;
+}
+
+.filter-panel__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-panel__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #5b6b8a;
+}
+
+.filter-panel__select {
+  background: #f1f5f9;
+  border-radius: 12px;
+  padding: 12px 16px;
+  border: 1px solid transparent;
+  font-size: 1rem;
+  transition: border 0.2s ease;
+}
+
+.filter-panel__select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  background: white;
+}
+
+.filter-panel__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.filter-panel__fieldset {
+  margin: 0;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.filter-panel__options {
+  display: grid;
+  gap: 8px;
+}
+
+.filter-panel__option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: #1f2a44;
+}
+
+.filter-panel__option input {
+  accent-color: #3b82f6;
+}
+
+.filter-panel__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import './FilterPanel.css';
+
+function FilterPanel({
+  dimensions,
+  selectedDimension,
+  onDimensionChange,
+  filters,
+  onFilterToggle
+}) {
+  return (
+    <section className="filter-panel">
+      <div className="filter-panel__group">
+        <label htmlFor="dimension" className="filter-panel__label">
+          Dimension d'analyse
+        </label>
+        <select
+          id="dimension"
+          className="filter-panel__select"
+          value={selectedDimension}
+          onChange={(event) => onDimensionChange(event.target.value)}
+        >
+          {dimensions.map((dimension) => (
+            <option key={dimension.value} value={dimension.value}>
+              {dimension.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="filter-panel__filters">
+        {filters.map((filter) => (
+          <fieldset key={filter.field} className="filter-panel__fieldset">
+            <legend>{filter.label}</legend>
+            <div className="filter-panel__options">
+              {filter.values.map((value) => (
+                <label key={value} className="filter-panel__option">
+                  <input
+                    type="checkbox"
+                    checked={filter.selected.includes(value)}
+                    onChange={() => onFilterToggle(filter.field, value)}
+                  />
+                  <span>{value}</span>
+                </label>
+              ))}
+              {filter.values.length === 0 && (
+                <p className="filter-panel__empty">Aucune donnée disponible</p>
+              )}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+FilterPanel.propTypes = {
+  dimensions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  selectedDimension: PropTypes.string.isRequired,
+  onDimensionChange: PropTypes.func.isRequired,
+  filters: PropTypes.arrayOf(
+    PropTypes.shape({
+      field: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      values: PropTypes.arrayOf(PropTypes.string).isRequired,
+      selected: PropTypes.arrayOf(PropTypes.string).isRequired
+    })
+  ).isRequired,
+  onFilterToggle: PropTypes.func.isRequired
+};
+
+export default FilterPanel;

--- a/frontend/src/components/IndicatorBuilder.css
+++ b/frontend/src/components/IndicatorBuilder.css
@@ -1,0 +1,326 @@
+.indicator-builder {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0));
+  border-radius: 24px;
+  border: 1px solid rgba(59, 130, 246, 0.12);
+  padding: 32px;
+  display: grid;
+  gap: 32px;
+}
+
+.indicator-builder__intro {
+  display: grid;
+  gap: 12px;
+  max-width: 640px;
+}
+
+.indicator-builder__intro h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
+  color: #0f172a;
+}
+
+.indicator-builder__intro p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.indicator-builder__tag {
+  width: fit-content;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.indicator-builder__layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+  align-items: start;
+}
+
+.indicator-builder__form {
+  display: grid;
+  gap: 20px;
+  background: white;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 24px;
+  box-shadow: 0 12px 40px -24px rgba(30, 64, 175, 0.45);
+}
+
+.indicator-builder__field {
+  display: grid;
+  gap: 10px;
+}
+
+.indicator-builder__field label,
+.indicator-builder__field legend {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.indicator-builder__field input[type='text'],
+.indicator-builder__field select,
+.indicator-builder__field textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 10px 14px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+.indicator-builder__field textarea {
+  resize: vertical;
+}
+
+.indicator-builder__field input:focus,
+.indicator-builder__field select:focus,
+.indicator-builder__field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+}
+
+.indicator-builder__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.indicator-builder__toggle {
+  display: inline-grid;
+  grid-auto-flow: column;
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.indicator-builder__toggle button {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #1e3a8a;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.indicator-builder__toggle button:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.indicator-builder__toggle button.is-active {
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 6px 16px -12px rgba(37, 99, 235, 0.6);
+}
+
+.indicator-builder__helper {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.indicator-builder__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.indicator-builder__actions button {
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.indicator-builder__actions button[type='submit'] {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: white;
+  box-shadow: 0 10px 20px -10px rgba(37, 99, 235, 0.6);
+}
+
+.indicator-builder__actions button[type='submit']:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px -12px rgba(37, 99, 235, 0.7);
+}
+
+.indicator-builder__actions .secondary {
+  background: white;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  color: #1f2937;
+}
+
+.indicator-builder__actions .secondary:hover {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.indicator-builder__preview {
+  background: white;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 24px;
+  box-shadow: 0 12px 40px -24px rgba(30, 64, 175, 0.45);
+  display: grid;
+  gap: 18px;
+}
+
+.indicator-builder__preview h3 {
+  margin: 0;
+  color: #1e293b;
+}
+
+.indicator-builder__preview article {
+  display: grid;
+  gap: 12px;
+}
+
+.indicator-builder__preview header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.indicator-builder__preview header h4 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.indicator-builder__badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.indicator-builder__preview p {
+  margin: 0;
+  color: #475569;
+}
+
+.indicator-builder__preview ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #1f2937;
+  display: grid;
+  gap: 6px;
+}
+
+.indicator-builder__list {
+  background: white;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.indicator-builder__list h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.indicator-builder__list ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.indicator-builder__list li {
+  display: grid;
+  gap: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.indicator-builder__list li h4 {
+  margin: 0;
+  color: #1e293b;
+}
+
+.indicator-builder__list li p {
+  margin: 0;
+  color: #475569;
+}
+
+.indicator-builder__list dl {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.indicator-builder__list dl div {
+  display: flex;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+.indicator-builder__list dt {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.indicator-builder__list dd {
+  margin: 0;
+  color: #334155;
+}
+
+.indicator-builder__list button {
+  justify-self: start;
+  border-radius: 999px;
+  border: none;
+  padding: 8px 16px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #b91c1c;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.indicator-builder__list button:hover {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.indicator-builder__error {
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.indicator-builder__input--error {
+  border-color: rgba(220, 38, 38, 0.6) !important;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15);
+}
+
+@media (max-width: 960px) {
+  .indicator-builder {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .indicator-builder__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .indicator-builder__form,
+  .indicator-builder__preview {
+    box-shadow: none;
+  }
+}

--- a/frontend/src/components/IndicatorBuilder.jsx
+++ b/frontend/src/components/IndicatorBuilder.jsx
@@ -1,0 +1,346 @@
+import { useMemo, useState } from 'react';
+import './IndicatorBuilder.css';
+
+const UNIT_OPTIONS = [
+  { value: '€', label: 'Euro (€)' },
+  { value: '%', label: 'Pourcentage (%)' },
+  { value: 'nb', label: 'Nombre' }
+];
+
+const DIRECTION_OPTIONS = [
+  { value: 'ascending', label: 'Croissant', description: 'Plus la valeur est élevée, mieux c\'est.' },
+  { value: 'descending', label: 'Décroissant', description: 'Plus la valeur est faible, mieux c\'est.' }
+];
+
+const FREQUENCY_OPTIONS = [
+  { value: 'daily', label: 'Journalier' },
+  { value: 'weekly', label: 'Hebdomadaire' },
+  { value: 'monthly', label: 'Mensuel' },
+  { value: 'quarterly', label: 'Trimestriel' },
+  { value: 'yearly', label: 'Annuel' }
+];
+
+const SECTION_OPTIONS = [
+  { value: 'acquisition', label: 'Acquisition' },
+  { value: 'activation', label: 'Activation' },
+  { value: 'retention', label: 'Rétention' },
+  { value: 'revenue', label: 'Revenus' }
+];
+
+const SOURCE_OPTIONS = [
+  { value: 'revenue', label: 'Revenu total' },
+  { value: 'orders', label: 'Commandes' },
+  { value: 'leads', label: 'Leads marketing' },
+  { value: 'conversionRate', label: 'Taux de conversion' },
+  { value: 'averageOrderValue', label: 'Panier moyen' },
+  { value: 'revenuePerLead', label: 'Revenu par lead' }
+];
+
+const createDefaultForm = () => ({
+  name: '',
+  description: '',
+  unit: UNIT_OPTIONS[0].value,
+  direction: DIRECTION_OPTIONS[0].value,
+  tolerance: 5,
+  frequency: FREQUENCY_OPTIONS[1].value,
+  section: SECTION_OPTIONS[0].value,
+  source: SOURCE_OPTIONS[0].value
+});
+
+function IndicatorBuilder() {
+  const [form, setForm] = useState(createDefaultForm);
+  const [indicators, setIndicators] = useState([]);
+  const [errors, setErrors] = useState({});
+
+  const directionCopy = useMemo(
+    () =>
+      DIRECTION_OPTIONS.find((option) => option.value === form.direction)?.description ??
+      "Définissez si l'objectif doit augmenter ou diminuer.",
+    [form.direction]
+  );
+
+  const sourceLabel = useMemo(
+    () => SOURCE_OPTIONS.find((option) => option.value === form.source)?.label ?? 'Indicateur lié',
+    [form.source]
+  );
+
+  const sectionLabel = useMemo(
+    () => SECTION_OPTIONS.find((option) => option.value === form.section)?.label ?? 'Section',
+    [form.section]
+  );
+
+  const toleranceSummary = useMemo(() => {
+    if (form.unit === '%') {
+      return `${form.tolerance} points de ${form.unit}`;
+    }
+    if (form.unit === '€') {
+      return `${form.tolerance} ${form.unit}`;
+    }
+    return `${form.tolerance} ${form.unit === 'nb' ? 'unités' : ''}`;
+  }, [form.tolerance, form.unit]);
+
+  const preview = useMemo(
+    () => ({
+      name: form.name || 'Nom de l\'indicateur',
+      description:
+        form.description ||
+        "Ajoutez une description pour contextualiser l\'indicateur auprès de vos équipes.",
+      details: [
+        `${sourceLabel} suivis en ${UNIT_OPTIONS.find((unit) => unit.value === form.unit)?.label}.`,
+        `Période d'analyse : ${FREQUENCY_OPTIONS.find((frequency) => frequency.value === form.frequency)?.label}.`,
+        `${directionCopy} Tolérance de ${toleranceSummary}.`,
+        `Organisé dans la section "${sectionLabel}".`
+      ]
+    }),
+    [directionCopy, form.description, form.frequency, form.name, form.unit, sectionLabel, sourceLabel, toleranceSummary]
+  );
+
+  const handleChange = (field, value) => {
+    setForm((previous) => ({
+      ...previous,
+      [field]: value
+    }));
+    setErrors((previous) => ({
+      ...previous,
+      [field]: undefined
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const nextErrors = {};
+    if (!form.name.trim()) {
+      nextErrors.name = "Donnez un nom à l'indicateur";
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    const newIndicator = {
+      ...form,
+      id: `${form.name}-${Date.now()}`
+    };
+
+    setIndicators((previous) => [newIndicator, ...previous]);
+    setForm(createDefaultForm());
+  };
+
+  const handleReset = () => {
+    setForm(createDefaultForm());
+    setErrors({});
+  };
+
+  const handleRemove = (id) => {
+    setIndicators((previous) => previous.filter((indicator) => indicator.id !== id));
+  };
+
+  return (
+    <section className="indicator-builder">
+      <div className="indicator-builder__intro">
+        <span className="indicator-builder__tag">Indicateurs personnalisés</span>
+        <h2>Créez vos indicateurs clés en quelques clics</h2>
+        <p>
+          Définissez le nom, l'unité, le sens de variation et la tolérance de vos KPI. Choisissez la fréquence de
+          suivi, liez-les à vos sections métier et partagez une description pour aligner vos équipes.
+        </p>
+      </div>
+
+      <div className="indicator-builder__layout">
+        <form className="indicator-builder__form" onSubmit={handleSubmit}>
+          <div className="indicator-builder__field">
+            <label htmlFor="indicator-name">Nom de l'indicateur</label>
+            <input
+              id="indicator-name"
+              type="text"
+              placeholder="Ex: Taux de transformation site"
+              value={form.name}
+              onChange={(event) => handleChange('name', event.target.value)}
+              className={errors.name ? 'indicator-builder__input--error' : ''}
+            />
+            {errors.name && <span className="indicator-builder__error">{errors.name}</span>}
+          </div>
+
+          <div className="indicator-builder__grid">
+            <div className="indicator-builder__field">
+              <label htmlFor="indicator-unit">Unité</label>
+              <select
+                id="indicator-unit"
+                value={form.unit}
+                onChange={(event) => handleChange('unit', event.target.value)}
+              >
+                {UNIT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="indicator-builder__field">
+              <label htmlFor="indicator-frequency">Fréquence de suivi</label>
+              <select
+                id="indicator-frequency"
+                value={form.frequency}
+                onChange={(event) => handleChange('frequency', event.target.value)}
+              >
+                {FREQUENCY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <fieldset className="indicator-builder__field">
+            <legend>Sens de variation</legend>
+            <div className="indicator-builder__toggle">
+              {DIRECTION_OPTIONS.map((option) => {
+                const isActive = option.value === form.direction;
+                return (
+                  <button
+                    type="button"
+                    key={option.value}
+                    onClick={() => handleChange('direction', option.value)}
+                    className={isActive ? 'is-active' : ''}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="indicator-builder__helper">{directionCopy}</p>
+          </fieldset>
+
+          <div className="indicator-builder__field">
+            <label htmlFor="indicator-tolerance">
+              Tolérance ({toleranceSummary})
+            </label>
+            <input
+              id="indicator-tolerance"
+              type="range"
+              min="0"
+              max="50"
+              step="1"
+              value={form.tolerance}
+              onChange={(event) => handleChange('tolerance', Number(event.target.value))}
+            />
+          </div>
+
+          <div className="indicator-builder__field">
+            <label htmlFor="indicator-section">Section métier</label>
+            <select
+              id="indicator-section"
+              value={form.section}
+              onChange={(event) => handleChange('section', event.target.value)}
+            >
+              {SECTION_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="indicator-builder__field">
+            <label htmlFor="indicator-source">Donnée associée</label>
+            <select
+              id="indicator-source"
+              value={form.source}
+              onChange={(event) => handleChange('source', event.target.value)}
+            >
+              {SOURCE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="indicator-builder__field">
+            <label htmlFor="indicator-description">Description</label>
+            <textarea
+              id="indicator-description"
+              rows="3"
+              placeholder="Ajoutez un contexte ou la formule de calcul pour vos équipes."
+              value={form.description}
+              onChange={(event) => handleChange('description', event.target.value)}
+            />
+          </div>
+
+          <div className="indicator-builder__actions">
+            <button type="submit">Enregistrer l'indicateur</button>
+            <button type="button" onClick={handleReset} className="secondary">
+              Réinitialiser
+            </button>
+          </div>
+        </form>
+
+        <aside className="indicator-builder__preview">
+          <h3>Prévisualisation</h3>
+          <article>
+            <header>
+              <h4>{preview.name}</h4>
+              <span className="indicator-builder__badge">{sourceLabel}</span>
+            </header>
+            <p>{preview.description}</p>
+            <ul>
+              {preview.details.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ul>
+          </article>
+        </aside>
+      </div>
+
+      {indicators.length > 0 && (
+        <div className="indicator-builder__list">
+          <h3>Indicateurs enregistrés</h3>
+          <ul>
+            {indicators.map((indicator) => (
+              <li key={indicator.id}>
+                <div>
+                  <h4>{indicator.name}</h4>
+                  <p>{indicator.description || 'Aucune description fournie.'}</p>
+                  <dl>
+                    <div>
+                      <dt>Unité</dt>
+                      <dd>{UNIT_OPTIONS.find((option) => option.value === indicator.unit)?.label}</dd>
+                    </div>
+                    <div>
+                      <dt>Variation</dt>
+                      <dd>
+                        {DIRECTION_OPTIONS.find((option) => option.value === indicator.direction)?.label} - Tolérance :{' '}
+                        {indicator.tolerance} {indicator.unit === 'nb' ? 'unités' : indicator.unit}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Fréquence</dt>
+                      <dd>{FREQUENCY_OPTIONS.find((option) => option.value === indicator.frequency)?.label}</dd>
+                    </div>
+                    <div>
+                      <dt>Section</dt>
+                      <dd>{SECTION_OPTIONS.find((option) => option.value === indicator.section)?.label}</dd>
+                    </div>
+                    <div>
+                      <dt>Donnée</dt>
+                      <dd>{SOURCE_OPTIONS.find((option) => option.value === indicator.source)?.label}</dd>
+                    </div>
+                  </dl>
+                </div>
+                <button type="button" onClick={() => handleRemove(indicator.id)}>
+                  Retirer
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default IndicatorBuilder;

--- a/frontend/src/components/KpiCard.css
+++ b/frontend/src/components/KpiCard.css
@@ -1,0 +1,51 @@
+.kpi-card {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kpi-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+}
+
+.kpi-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.kpi-card__title {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: #5b6b8a;
+}
+
+.kpi-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #7b8bab;
+}
+
+.kpi-card__value {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #172b4d;
+}
+
+.kpi-card--success .kpi-card__value {
+  color: #0f7b6c;
+}
+
+.kpi-card--warning .kpi-card__value {
+  color: #b25a0b;
+}

--- a/frontend/src/components/KpiCard.jsx
+++ b/frontend/src/components/KpiCard.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import './KpiCard.css';
+
+function KpiCard({ title, value, description, tone = 'default' }) {
+  return (
+    <article className={`kpi-card kpi-card--${tone}`}>
+      <header className="kpi-card__header">
+        <p className="kpi-card__title">{title}</p>
+        <p className="kpi-card__description">{description}</p>
+      </header>
+      <p className="kpi-card__value">{value}</p>
+    </article>
+  );
+}
+
+KpiCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  tone: PropTypes.oneOf(['default', 'success', 'warning'])
+};
+
+export default KpiCard;

--- a/frontend/src/components/SegmentTable.css
+++ b/frontend/src/components/SegmentTable.css
@@ -1,0 +1,57 @@
+.segment-table {
+  background: white;
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.segment-table__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #111827;
+}
+
+.segment-table__header p {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.segment-table__scroller {
+  overflow-x: auto;
+}
+
+.segment-table table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.segment-table th,
+.segment-table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.segment-table thead th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.segment-table tbody tr:nth-child(odd) {
+  background: rgba(241, 245, 249, 0.5);
+}
+
+.segment-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.segment-table--empty {
+  text-align: center;
+  color: #64748b;
+}

--- a/frontend/src/components/SegmentTable.jsx
+++ b/frontend/src/components/SegmentTable.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import './SegmentTable.css';
+
+function SegmentTable({ dimensionLabel, rows }) {
+  if (rows.length === 0) {
+    return (
+      <section className="segment-table segment-table--empty">
+        <p>Aucun segment disponible pour cette sélection.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="segment-table">
+      <header className="segment-table__header">
+        <h2>Performance par {dimensionLabel.toLowerCase()}</h2>
+        <p>Comparez les KPIs clés par segment pour identifier les leviers de croissance.</p>
+      </header>
+      <div className="segment-table__scroller">
+        <table>
+          <thead>
+            <tr>
+              <th>{dimensionLabel}</th>
+              <th>Revenu</th>
+              <th>Commandes</th>
+              <th>Leads</th>
+              <th>Taux de conversion</th>
+              <th>Panier moyen</th>
+              <th>Revenu / Lead</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.dimension}>
+                <th scope="row">{row.dimension}</th>
+                <td>{row.kpis.revenue}</td>
+                <td>{row.kpis.orders}</td>
+                <td>{row.kpis.leads}</td>
+                <td>{row.kpis.conversionRate}</td>
+                <td>{row.kpis.averageOrderValue}</td>
+                <td>{row.kpis.revenuePerLead}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+SegmentTable.propTypes = {
+  dimensionLabel: PropTypes.string.isRequired,
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      dimension: PropTypes.string.isRequired,
+      kpis: PropTypes.shape({
+        revenue: PropTypes.string.isRequired,
+        orders: PropTypes.string.isRequired,
+        leads: PropTypes.string.isRequired,
+        conversionRate: PropTypes.string.isRequired,
+        averageOrderValue: PropTypes.string.isRequired,
+        revenuePerLead: PropTypes.string.isRequired
+      }).isRequired
+    })
+  ).isRequired
+};
+
+export default SegmentTable;

--- a/frontend/src/data/sampleTransactions.json
+++ b/frontend/src/data/sampleTransactions.json
@@ -1,0 +1,12 @@
+[
+  {"date": "2024-01-01", "revenue": 1250.5, "leads": 120, "orders": 24, "channel": "Email", "campaign": "Winter Blast", "product": "Analytics Suite"},
+  {"date": "2024-01-02", "revenue": 980.0, "leads": 90, "orders": 18, "channel": "Email", "campaign": "Winter Blast", "product": "Analytics Suite"},
+  {"date": "2024-01-03", "revenue": 1420.75, "leads": 150, "orders": 30, "channel": "Ads", "campaign": "Search 2024", "product": "Marketing Hub"},
+  {"date": "2024-01-04", "revenue": 1110.25, "leads": 80, "orders": 16, "channel": "Ads", "campaign": "Retargeting", "product": "Analytics Suite"},
+  {"date": "2024-01-05", "revenue": 1675.0, "leads": 200, "orders": 40, "channel": "Direct", "campaign": "Website", "product": "Marketing Hub"},
+  {"date": "2024-01-06", "revenue": 890.3, "leads": 75, "orders": 15, "channel": "Partners", "campaign": "Agency", "product": "Analytics Suite"},
+  {"date": "2024-01-07", "revenue": 2100.9, "leads": 220, "orders": 44, "channel": "Ads", "campaign": "Search 2024", "product": "Analytics Suite"},
+  {"date": "2024-01-08", "revenue": 1345.1, "leads": 140, "orders": 28, "channel": "Email", "campaign": "New Leads", "product": "Marketing Hub"},
+  {"date": "2024-01-09", "revenue": 1560.0, "leads": 160, "orders": 32, "channel": "Direct", "campaign": "Website", "product": "Analytics Suite"},
+  {"date": "2024-01-10", "revenue": 1025.75, "leads": 95, "orders": 19, "channel": "Partners", "campaign": "Agency", "product": "Marketing Hub"}
+]

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,25 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #172b4d;
+  background-color: #f7f9fc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});

--- a/main.py
+++ b/main.py
@@ -1,5 +1,79 @@
-def main():
-    print("Hello from sand!")
+"""Command line interface for the ABC KPI analytical platform."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from abckpi_platform import KPIEngine, format_report, load_transactions
+from abckpi_platform.reporting import format_grouped_report
+
+
+def _coerce_value(value: str) -> str | float | int:
+    try:
+        int_value = int(value)
+    except ValueError:
+        try:
+            float_value = float(value)
+        except ValueError:
+            return value
+        else:
+            return float_value
+    else:
+        return int_value
+
+
+def parse_filters(values: Iterable[str]) -> list[tuple[str, str | float | int]]:
+    filters: list[tuple[str, str | float | int]] = []
+    for value in values:
+        if "=" not in value:
+            raise argparse.ArgumentTypeError(
+                f"Invalid filter '{value}'. Expected the form column=value"
+            )
+        column, raw_value = value.split("=", 1)
+        filters.append((column, _coerce_value(raw_value)))
+    return filters
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset", type=Path, help="Path to the CSV dataset")
+    parser.add_argument("--currency", default="€", help="Currency symbol for the report")
+    parser.add_argument(
+        "--filter",
+        dest="filters",
+        metavar="COLUMN=VALUE",
+        action="append",
+        default=[],
+        help="Filter the dataset by equality. Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--dimension",
+        dest="dimension",
+        help="Optional column used to build a segmented report.",
+    )
+    return parser
+
+
+def main(args: list[str] | None = None) -> str:
+    parser = build_parser()
+    options = parser.parse_args(args=args)
+
+    filters = parse_filters(options.filters)
+
+    frame = load_transactions(options.dataset, filters=filters)
+
+    engine = KPIEngine(frame, currency=options.currency)
+    summary = engine.compute()
+    output = [format_report(summary)]
+
+    if options.dimension:
+        grouped = engine.by_dimension(options.dimension)
+        output.append(format_grouped_report(grouped))
+
+    report = "\n\n".join(output)
+    print(report)
+    return report
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a Vite-powered React frontend that mirrors the KPI platform with filters, summary cards, and segmented reporting
- implement reusable UI components and sample dataset for the dashboard experience
- document how to run the React app and ignore Node build artifacts

## Testing
- python main.py data/sample_transactions.csv --dimension channel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134f13a998832388107759818a49bb)